### PR TITLE
add search_analyze endpoint

### DIFF
--- a/src/search3_httpd.erl
+++ b/src/search3_httpd.erl
@@ -1,6 +1,6 @@
 -module(search3_httpd).
 
--export([handle_search_req/3]).
+-export([handle_search_req/3, handle_analyze_req/1]).
 
 -include("search3.hrl").
 -include_lib("couch/include/couch_db.hrl").
@@ -58,6 +58,52 @@ handle_search_req(#httpd{path_parts=[_, _, _, _, _]}=Req, _Db, _DDoc,
     send_method_not_allowed(Req, "GET,POST");
 handle_search_req(Req, _Db, _DDoc, _RetryCount, _RetryPause) ->
     send_error(Req, {bad_request, "path not recognized"}).
+
+handle_analyze_req(#httpd{method='GET'}=Req) ->
+    Analyzer = couch_httpd:qs_value(Req, "analyzer"),
+    Text = couch_httpd:qs_value(Req, "text"),
+    analyze(Req, Analyzer, Text);
+handle_analyze_req(#httpd{method='POST'}=Req) ->
+    couch_httpd:validate_ctype(Req, "application/json"),
+    {Fields} = chttpd:json_body_obj(Req),
+    Analyzer = couch_util:get_value(<<"analyzer">>, Fields),
+    Text = couch_util:get_value(<<"text">>, Fields),
+    analyze(Req, Analyzer, Text);
+handle_analyze_req(Req) ->
+    send_method_not_allowed(Req, "GET,POST").
+
+analyze(Req, Analyzer, Text) ->
+    case Analyzer of
+        undefined ->
+            throw({bad_request, "analyzer parameter is mandatory"});
+        _ when is_list(Analyzer) ->
+            ok;
+        _ when is_binary(Analyzer) ->
+            ok;
+        {[_|_]} ->
+            ok;
+        _ ->
+            throw({bad_request, "analyzer parameter must be a string or an object"})
+    end,
+    case Text of
+        undefined ->
+            throw({bad_request, "text parameter is mandatory"});
+        _ when is_list(Text) ->
+            ok;
+        _ when is_binary(Text) ->
+            ok;
+        _ ->
+            throw({bad_request, "text parameter must be a string"})
+    end,
+    Response = search3_rpc:analyze(couch_util:to_binary(Analyzer),
+        couch_util:to_binary(Text)),
+    couch_log:notice("Response ~p", [Response]),
+    case search3_response:handle_analyze_response(Response) of
+        {ok, Tokens} ->
+            send_json(Req, 200, {[{tokens, Tokens}]});
+        {error, Reason} ->
+            send_error(Req, Reason)
+    end.
 
 parse_index_params(#httpd{method='GET'}=Req, Db) ->
     IndexParams = lists:flatmap(fun({K, V}) -> parse_index_param(K, V) end,

--- a/src/search3_httpd_handlers.erl
+++ b/src/search3_httpd_handlers.erl
@@ -13,3 +13,4 @@ design_handler(<<"_search">>) -> fun search3_httpd:handle_search_req/3;
 design_handler(_) -> no_match.
 
 db_handler(_) -> no_match.
+

--- a/src/search3_httpd_handlers.erl
+++ b/src/search3_httpd_handlers.erl
@@ -6,11 +6,10 @@
     design_handler/1
 ]).
 
+url_handler(<<"_search_analyze">>) -> fun search3_httpd:handle_analyze_req/1;
 url_handler(_) -> no_match.
 
 design_handler(<<"_search">>) -> fun search3_httpd:handle_search_req/3;
 design_handler(_) -> no_match.
 
 db_handler(_) -> no_match.
-
-

--- a/src/search3_response.erl
+++ b/src/search3_response.erl
@@ -7,7 +7,8 @@
     facets_to_json/1,
 
     handle_response/2,
-    handle_search_response/2
+    handle_search_response/2,
+    handle_analyze_response/1
 ]).
 
 hits_to_json(Db, IncludeDocs, Hits) ->
@@ -114,6 +115,11 @@ handle_search_response({ok, Response, _Header}, BuildSession) ->
     Ranges = maps:get(ranges, Response, undefined),
     {search, Bookmark, Matches, Hits, Counts, Ranges};
 handle_search_response({error, Error}, _) ->
+    handle_error_response({error, Error}).
+
+handle_analyze_response({ok,  #{tokens := Tokens}, _}) ->
+    {ok, Tokens};
+handle_analyze_response({error, Error}) ->
     handle_error_response({error, Error}).
 
 % Handles generic responses for now to simply verify session is the same

--- a/src/search3_rpc.erl
+++ b/src/search3_rpc.erl
@@ -12,7 +12,8 @@
     update_index/5,
     search_index/2,
     set_update_seq/3,
-    get_channel/0
+    get_channel/0,
+    analyze/2
     ]).
 
 get_update_seq(Index) ->
@@ -77,6 +78,10 @@ search_index(Index, QueryArgs) ->
             GroupMsg = construct_group_msg(IndexMsg, QueryArgs),
             search_client:group_search(GroupMsg, get_channel())
     end.
+
+analyze(AnalyzerName, Text) ->
+    AnalyzeMsg = #{analyzer => #{name => AnalyzerName}, text => Text},
+    search_client:analyze(AnalyzeMsg, get_channel()).
 
 %% Internal
 


### PR DESCRIPTION
This adds the search_analyze endpoint for search3
```
{"analyzer":"keyword", "text":"ablanks@renovations.com"}

{
    "tokens": [
        "ablanks@renovations.com"
    ]
}
```