### PR TITLE
skip document during indexing if error occurs

### DIFF
--- a/src/search3_response.erl
+++ b/src/search3_response.erl
@@ -8,6 +8,7 @@
 
     handle_response/2,
     handle_search_response/2,
+    handle_update_response/2,
     handle_analyze_response/1
 ]).
 
@@ -129,6 +130,12 @@ handle_response({ok, #{session := Session} = Response, _},
     VSession = verify_same_session(CurrentSession, Session),
     {VSession, Response};
 handle_response({error, Error}, _) ->
+    handle_error_response({error, Error}).
+
+handle_update_response({ok, #{session := Session}, _}, CurrentSession) ->
+    VSession = verify_same_session(CurrentSession, Session),
+    VSession;
+handle_update_response({error, Error}, _) ->
     handle_error_response({error, Error}).
 
 handle_error_response({error, {<<"9">>, Msg}}) ->

--- a/src/search3_rpc.erl
+++ b/src/search3_rpc.erl
@@ -47,7 +47,7 @@ delete_index(#index{session = Session} = Index, Id, Seq, PurgeSeq) ->
         purge_seq => #{seq => PurgeSeq}
     },
     Resp = search_client:delete_document(Msg, get_channel()),
-    search3_response:handle_response(Resp, Session).
+    search3_response:handle_update_response(Resp, Session).
 
 info_index(#index{session = Session} = Index) ->
     IndexMsg = construct_index_msg(Index),
@@ -65,7 +65,7 @@ update_index(#index{session = Session} = Index, Id, Seq, PurgeSeq, Fields) ->
         fields => Fields1
     },
     Resp = search_client:update_document(Msg, get_channel()),
-    search3_response:handle_response(Resp, Session).
+    search3_response:handle_update_response(Resp, Session).
 
 search_index(Index, QueryArgs) ->
     #index_query_args{grouping = Grouping} = QueryArgs,


### PR DESCRIPTION
When an error is returned by search3-java, we handle it by throwing a
generic bad_request exception. This is the error handling path for both
search and indexing requests. During indexing however, the exception is
not caught and it leads to a search_worker_manager process crash. The
process is restarted by the search3_sup supervisor and the indexing
begins again. This leads to an endless loop of trying to index the same
document if the documents causes some sort of error. We modify this
behavior by catching the thrown exception and ignoring the document.