### PR TITLE
Selectively disable search indexing based on node types

### DIFF
--- a/src/search3_app.erl
+++ b/src/search3_app.erl
@@ -14,7 +14,7 @@
     stop/1
 ]).
 
-start(_StartType, StartArgs) ->
+start(_StartType, _StartArgs) ->
     {ok, _} = application:ensure_all_started(grpcbox),
     Url = config:get("search3", "service_url", "localhost"),
     Port = case config:get("search3", "service_port", 8443) of
@@ -23,7 +23,7 @@ start(_StartType, StartArgs) ->
     end,
     Endpoints = [{http, Url, Port, []}],
     {ok, _} = grpcbox_channel_sup:start_child(?SEARCH_CHANNEL, Endpoints, #{}),
-    search3_sup:start_link(StartArgs).
+    search3_sup:start_link().
 
 stop(_State) ->
     ok.

--- a/src/search3_sup.erl
+++ b/src/search3_sup.erl
@@ -3,27 +3,39 @@
 -behaviour(supervisor).
 
 -export([
-    start_link/1
+    start_link/0
 ]).
 
 -export([
     init/1
 ]).
 
-start_link(Args) ->
-    supervisor:start_link({local, ?MODULE}, ?MODULE, Args).
+start_link() ->
+    Arg = case fabric2_node_types:is_type(search_indexing) of
+        true -> normal;
+        false -> builds_disabled
+    end,
+    supervisor:start_link({local, ?MODULE}, ?MODULE, Arg).
 
 
-init([]) ->
-    Flags = #{
-        strategy => one_for_all,
-        intensity => 1,
-        period => 5
-    },
+init(normal) ->
     Children = [
         #{
             id => search3_worker_manager,
             start => {search3_worker_manager, start_link, []}
         }
     ],
-    {ok, {Flags, Children}}.
+    {ok, {flags(), Children}};
+
+init(builds_disabled) ->
+    couch_log:notice("~p : search_indexing disabled", [?MODULE]),
+    search3_jobs:set_timeout(),
+    {ok, {flags(), []}}.
+
+
+flags() ->
+    #{
+        strategy => one_for_all,
+        intensity => 1,
+        period => 5
+    },


### PR DESCRIPTION
Follows the "Node types" [RFC] and the implementation from [CouchDB] for `view_indexing`.

[RFC]: https://github.com/apache/couchdb-documentation/blob/master/rfcs/013-node-types.md
[CouchDB]: apache/couchdb@5e47f50